### PR TITLE
Reduce the need for some android settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,24 +159,6 @@ Add the following keys to `Info.plist.`:
 
 ### Android
 
-Configure `AndroidManifest.xml`:
-```xml
-<manifest>
-    <application>
-        <service
-            android:name="com.equimaps.capacitor_background_geolocation.BackgroundGeolocationService"
-            android:enabled="true"
-            android:exported="true"
-            android:foregroundServiceType="location" />
-    </application>
-
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-feature android:name="android.hardware.location.gps" />
-</manifest>
-```
-
 Configration specific to Android can be made in `strings.xml`:
 ```xml
 <resources>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.equimaps.capacitor_background_geolocation">
+    <application>
+        <service
+            android:name="com.equimaps.capacitor_background_geolocation.BackgroundGeolocationService"
+            android:enabled="true"
+            android:exported="true"
+            android:foregroundServiceType="location" />
+    </application>
+
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-feature android:name="android.hardware.location.gps" />
 </manifest>
   

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,16 +30,7 @@
                 <data android:scheme="@string/custom_url_scheme" />
             </intent-filter>
         </activity>
-
-        <service
-            android:name="com.equimaps.capacitor_background_geolocation.BackgroundGeolocationService"
-            android:enabled="true"
-            android:exported="true"
-            android:foregroundServiceType="location" />
     </application>
 
     <!-- Permissions -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-feature android:name="android.hardware.location.gps" />
 </manifest>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -13,12 +13,11 @@
         "@capacitor/cli": "^4.0.0",
         "@capacitor/core": "^4.0.0",
         "@capacitor/ios": "^4.0.0"
-      },
-      "devDependencies": {}
+      }
     },
     "..": {
       "name": "@capacitor-community/background-geolocation",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^4.0.0",


### PR DESCRIPTION
Related to the discussion in #73 - this PR will automatically add the Manifest.xml parts related to Android build.
I've added it to the manifest and removed it from the readme.
I've took the inspiration from:
https://github.com/ionic-team/capacitor-plugins/blob/d97898662d0ba037e5f8448990a91de5ec6a4234/local-notifications/android/src/main/AndroidManifest.xml

I'm not sure where to put the part saying this should be removed from the Manifest.xml in case you upgrade from a previous version though...

Any thought are welcome!
Thanks for all the work around this plugin!
I've took it from some test run with my phone and app and it seems to run very well in the background :-)