### PR TITLE
Fix androidxAppCompatVersion in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxLocalbroadcastmanagerVersion = project.hasProperty('androidxLocalbroadcastmanagerVersion') ? rootProject.ext.androidxLocalbroadcastmanagerVersion : '1.0.0'
     playServicesLocationVersion = project.hasProperty('playServicesLocationVersion') ? rootProject.ext.playServicesLocationVersion : '21.0.1'
 }


### PR DESCRIPTION
Fixes issue with gradle sync failed because there was no `androidxAppCompatVersion` provided.
Added default value from Capacitor v6 since other configurations are not adjusted for v7 yet.