### PR TITLE
Make service more persistent 

### DIFF
--- a/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -286,6 +286,7 @@ public class BackgroundGeolocation extends Plugin {
     public void load() {
         super.load();
 
+        Intent serviceIntent = new Intent(this.getContext(), BackgroundGeolocationService.class);
         // Android O requires a Notification Channel.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationManager manager = (NotificationManager) getContext().getSystemService(
@@ -303,10 +304,13 @@ public class BackgroundGeolocation extends Plugin {
             channel.enableVibration(false);
             channel.setSound(null, null);
             manager.createNotificationChannel(channel);
+            this.getContext().startForegroundService(serviceIntent);
+        } else {
+            this.getContext().startService(serviceIntent);
         }
 
         this.getContext().bindService(
-                new Intent(this.getContext(), BackgroundGeolocationService.class),
+                serviceIntent,
                 new ServiceConnection() {
                     @Override
                     public void onServiceConnected(ComponentName name, IBinder binder) {

--- a/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -43,6 +43,11 @@ public class BackgroundGeolocationService extends Service {
     private HashSet<Watcher> watchers = new HashSet<Watcher>();
 
     @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+    
+    @Override
     public IBinder onBind(Intent intent) {
         return binder;
     }


### PR DESCRIPTION
This should make the service more persistent on Android.
As far as I could tell, this is the main difference between this plugin and the plugin I maintain.
Moreover, it seems that Gimini says that this might be related to the below issue:

- Fixes #80 

From an initial test I made today with this code it seems that this code was able to record a 3 hours walk with a 1 hour stop in the middle, so I think it's a good test.
The original bug (#80) was a hard one to reproduce but I think the coded added here is minimal and won't affect this plugin negatively.
It doesn't change any public API.
It makes the service sticky and initialize it using a recommended approach.