### PR TITLE
Add runtime permission request to post notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Add the following keys to `Info.plist.`:
 
 Set the the `android.useLegacyBridge` option to `true` in your Capacitor configuration. This prevents location updates halting after 5 minutes in the background. See https://capacitorjs.com/docs/config and https://github.com/capacitor-community/background-geolocation/issues/89.
 
-On Android 13+, the app needs the `POST_NOTIFICATIONS` runtime permission to show the persistent notification informing the user that their location is being used in the background. You may need to [request this permission](https://developer.android.com/develop/ui/views/notifications/notification-permission) from the user, this can be accomplished [using the `@capacitor/local-notifications` plugin](https://capacitorjs.com/docs/apis/local-notifications#checkpermissions).
+On Android 13+, the app needs the `POST_NOTIFICATIONS` runtime permission to show the persistent notification informing the user that their location is being used in the background. this plugin will [request this permission](https://developer.android.com/develop/ui/views/notifications/notification-permission) from the user if `backgroundMessage` is defined in the `addWatcher` options.
 
 If your app forwards location updates to a server in real time, be aware that after 5 minutes in the background Android will throttle HTTP requests initiated from the WebView. The solution is to use a native HTTP plugin such as [CapacitorHttp](https://capacitorjs.com/docs/apis/http). See https://github.com/capacitor-community/background-geolocation/issues/14.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Add the following keys to `Info.plist.`:
 
 Set the the `android.useLegacyBridge` option to `true` in your Capacitor configuration. This prevents location updates halting after 5 minutes in the background. See https://capacitorjs.com/docs/config and https://github.com/capacitor-community/background-geolocation/issues/89.
 
-On Android 13+, the app needs the `POST_NOTIFICATIONS` runtime permission to show the persistent notification informing the user that their location is being used in the background. this plugin will [request this permission](https://developer.android.com/develop/ui/views/notifications/notification-permission) from the user if `backgroundMessage` is defined in the `addWatcher` options.
+On Android 13+, the app needs the `POST_NOTIFICATIONS` runtime permission to show the persistent notification informing the user that their location is being used in the background. This plugin will [request this permission](https://developer.android.com/develop/ui/views/notifications/notification-permission) from the user if `backgroundMessage` is defined in the `addWatcher` options.
 
 If your app forwards location updates to a server in real time, be aware that after 5 minutes in the background Android will throttle HTTP requests initiated from the WebView. The solution is to use a native HTTP plugin such as [CapacitorHttp](https://capacitorjs.com/docs/apis/http). See https://github.com/capacitor-community/background-geolocation/issues/14.
 


### PR DESCRIPTION
- Resolves #141

In this PR I did the following:
1. Made the indentation smaller by checking conditions and returning fast
2. I extracted the notification creation to a method
3. I Added runtime request for post notification when `backgroundMessage` is defined
4. I moved some methods around to facilitate cases where permission are granted and not granted.

This also solves an issue for when running the app for the first time and there was a code flow that would create the notification and create a watcher even though the permission is not granted, so there was an error in the logcat. 