### PR TITLE
Support interval and maxWaitTime for Android watchers

### DIFF
--- a/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -159,7 +159,9 @@ public class BackgroundGeolocation extends Plugin {
         service.addWatcher(
                 call.getCallbackId(),
                 backgroundNotification,
-                call.getFloat("distanceFilter", 0f)
+            call.getFloat("distanceFilter", 0f),
+            call.getInt("interval", 1000),
+            call.getInt("maxWaitTime", call.getInt("interval", 1000))
         );
     }
 

--- a/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/equimaps/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -75,14 +75,17 @@ public class BackgroundGeolocationService extends Service {
         void addWatcher(
                 final String id,
                 Notification backgroundNotification,
-                float distanceFilter
+            float distanceFilter,
+            int interval,
+            int maxWaitTime
         ) {
             FusedLocationProviderClient client = LocationServices.getFusedLocationProviderClient(
                     BackgroundGeolocationService.this
             );
             LocationRequest locationRequest = new LocationRequest();
-            locationRequest.setMaxWaitTime(1000);
-            locationRequest.setInterval(1000);
+            locationRequest.setMaxWaitTime(maxWaitTime);
+            locationRequest.setInterval(interval);
+            locationRequest.setFastestInterval(interval);
             locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
             locationRequest.setSmallestDisplacement(distanceFilter);
 

--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -37,6 +37,8 @@ export interface WatcherOptions {
      * @default 0
      */
     distanceFilter?: number;
+    interval?: number;
+    maxWaitTime?: number;
 }
 
 /**


### PR DESCRIPTION
This pull request enhances the location update configuration by allowing clients to specify custom `interval` and `maxWaitTime` values for location requests, providing more flexibility over how frequently location updates are received and batched.

**Location update configuration improvements:**

* The `addWatcher` method in `BackgroundGeolocation.java` now accepts `interval` and `maxWaitTime` parameters from the plugin call, with sensible defaults if not provided.
* The `addWatcher` method in `BackgroundGeolocationService.java` has been updated to use the provided `interval` and `maxWaitTime` values when configuring the `LocationRequest`, and also sets the `fastestInterval` to match the `interval` for consistent update timing.